### PR TITLE
Delete `cairo_project.toml`

### DIFF
--- a/cairo_project.toml
+++ b/cairo_project.toml
@@ -1,2 +1,0 @@
-[crate_roots]
-avnu = "src"


### PR DESCRIPTION
This is unused by your package and causes [Maat](https://docs.swmansion.com/maat/) (sth akin to Rust https://crater.rust-lang.org/ for Cairo) to detect false language server failure